### PR TITLE
chore(fix): renovate ignores version update for our own API and updat…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,26 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "github.com/openmcp-project/*"
+      ],
+      "description": "Update all components from openmcp-project immediately",
+      "rebaseWhen": "auto",
+      "minimumReleaseAge": "0 days",
+      "enabled": true
+    },
+    {
+      "description": "Ignore version update for our own API",
+      "matchManagers": [
+        "gomod"
+      ],
+      "enabled": false,
+      "matchPackageNames": [
+        "github.com/openmcp-project/cluster-provider-gardener/api"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

renovate ignores version update for our own API and updates components from openmcp-project immediately

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
NONE
```
