### PR TITLE
make provider name and accessrequest serviceaccount namespace configurable via env vars

### DIFF
--- a/internal/controllers/accessrequest/access.go
+++ b/internal/controllers/accessrequest/access.go
@@ -302,9 +302,9 @@ func (r *AccessRequestReconciler) renewToken(ctx context.Context, ac *clustersv1
 	}
 
 	// ensure namespace
-	_, err := clusteraccess.EnsureNamespace(ctx, sac.Client, shared.AccessRequestSANamespace())
+	_, err := clusteraccess.EnsureNamespace(ctx, sac.Client, shared.AccessRequestServiceAccountNamespace())
 	if err != nil {
-		rr.ReconcileError = errutils.WithReason(fmt.Errorf("error ensuring AccessRequest namespace '%s' in shoot '%s/%s': %w", shared.AccessRequestSANamespace(), sac.Shoot.Namespace, sac.Shoot.Name, err), cconst.ReasonShootClusterInteractionProblem)
+		rr.ReconcileError = errutils.WithReason(fmt.Errorf("error ensuring AccessRequest namespace '%s' in shoot '%s/%s': %w", shared.AccessRequestServiceAccountNamespace(), sac.Shoot.Namespace, sac.Shoot.Name, err), cconst.ReasonShootClusterInteractionProblem)
 		return nil, rr
 	}
 
@@ -313,9 +313,9 @@ func (r *AccessRequestReconciler) renewToken(ctx context.Context, ac *clustersv1
 
 	// ensure service account
 	name := ctrlutils.K8sNameHash(shared.Environment(), shared.ProviderName(), ac.Namespace, ac.Name)
-	sa, err := clusteraccess.EnsureServiceAccount(ctx, sac.Client, name, shared.AccessRequestSANamespace(), expectedLabels...)
+	sa, err := clusteraccess.EnsureServiceAccount(ctx, sac.Client, name, shared.AccessRequestServiceAccountNamespace(), expectedLabels...)
 	if err != nil {
-		rr.ReconcileError = errutils.WithReason(fmt.Errorf("error ensuring service account '%s/%s' in shoot '%s/%s': %w", shared.AccessRequestSANamespace(), name, sac.Shoot.Namespace, sac.Shoot.Name, err), cconst.ReasonShootClusterInteractionProblem)
+		rr.ReconcileError = errutils.WithReason(fmt.Errorf("error ensuring service account '%s/%s' in shoot '%s/%s': %w", shared.AccessRequestServiceAccountNamespace(), name, sac.Shoot.Namespace, sac.Shoot.Name, err), cconst.ReasonShootClusterInteractionProblem)
 		return nil, rr
 	}
 	if sa.GroupVersionKind().Kind == "" {

--- a/internal/controllers/shared/config.go
+++ b/internal/controllers/shared/config.go
@@ -23,9 +23,9 @@ import (
 )
 
 var (
-	environment              string
-	providerName             string
-	accessRequestSANamespace string
+	environment                          string
+	providerName                         string
+	accessRequestServiceAccountNamespace string
 )
 
 func SetEnvironment(env string) {
@@ -56,18 +56,18 @@ func ProviderName() string {
 	return providerName
 }
 
-func SetAccessRequestSANamespace(ns string) {
-	if accessRequestSANamespace != "" {
+func SetAccessRequestServiceAccountNamespace(ns string) {
+	if accessRequestServiceAccountNamespace != "" {
 		panic("accessrequest namespace already set")
 	}
-	accessRequestSANamespace = ns
+	accessRequestServiceAccountNamespace = ns
 }
 
-func AccessRequestSANamespace() string {
-	if accessRequestSANamespace == "" {
+func AccessRequestServiceAccountNamespace() string {
+	if accessRequestServiceAccountNamespace == "" {
 		panic("accessrequest namespace not set")
 	}
-	return accessRequestSANamespace
+	return accessRequestServiceAccountNamespace
 }
 
 // RuntimeConfiguration is a struct that holds the loaded ProviderConfigurations, enriched with further information gathered during runtime.


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Provider name and the namespace for AccessRequest ServiceAccounts can now be set via env vars.
```
