### PR TITLE
fix: inherit secrets for shared workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,3 +15,4 @@ permissions:
 jobs:
   build_validate_test:
     uses: openmcp-project/build/.github/workflows/ci.lib.yaml@main
+    secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,3 +12,4 @@ permissions:
 jobs:
   release_publish:
    uses: openmcp-project/build/.github/workflows/publish.lib.yaml@main
+   secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,3 +12,4 @@ permissions:
 jobs:
   release_tag:
     uses: openmcp-project/build/.github/workflows/release.lib.yaml@main
+    secrets: inherit

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -8,3 +8,4 @@ permissions:
 jobs:
   run_reuse:
     uses: openmcp-project/build/.github/workflows/reuse.lib.yaml@main
+    secrets: inherit

--- a/.github/workflows/validate-pr-content.yaml
+++ b/.github/workflows/validate-pr-content.yaml
@@ -12,3 +12,4 @@ permissions:
 jobs:
   validate_pr_content:
     uses: openmcp-project/build/.github/workflows/validate-pr-content.lib.yaml@main
+    secrets: inherit


### PR DESCRIPTION
**What this PR does / why we need it**:

In order for repository defined secrets to be passed to shared workflows, the parameter `secrets: inherit` must be set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Inherit secrets in shared workflows
```
