### PR TITLE
change PROVIDER_NAME env var to OPENMCP_PROVIDER_NAME

### DIFF
--- a/cmd/cluster-provider-gardener/app/app.go
+++ b/cmd/cluster-provider-gardener/app/app.go
@@ -85,7 +85,7 @@ func (o *SharedOptions) Complete() error {
 	}
 	shared.SetEnvironment(o.Environment)
 
-	o.ProviderName = os.Getenv("PROVIDER_NAME")
+	o.ProviderName = os.Getenv("OPENMCP_PROVIDER_NAME")
 	if o.ProviderName == "" {
 		o.ProviderName = "gardener"
 	}

--- a/docs/config/setup.md
+++ b/docs/config/setup.md
@@ -4,7 +4,7 @@
 
 There are a few environment variables that are evaluated on startup and can be used to control the behavior of the ClusterProvider:
 
-- `PROVIDER_NAME` can be overwritten to specify the provider name. It defaults to `gardener` if not set.
+- `OPENMCP_PROVIDER_NAME` can be overwritten to specify the provider name. It defaults to `gardener` if not set.
   - Must be a k8s name compatible string.
-  - The provider name is used as an identifier to avoid conflicts between multiple Gardener ClusterProviders working on the same k8s cluster. Its value doesn't really matter, as long as only one instance of the ClusterProvider is working on the cluster. If multipel instances are working on the same cluster, they must all have unique provider names to avoid conflicts on reconciled resources.
+  - The provider name is used as an identifier to avoid conflicts between multiple Gardener ClusterProviders working on the same k8s cluster. Its value doesn't really matter, as long as only one instance of the ClusterProvider is working on the cluster. If multiple instances are working on the same cluster, they must all have unique provider names to avoid conflicts on reconciled resources.
 - `ACCESS_REQUEST_SERVICE_ACCOUNT_NAMESPACE` specifies the namespace on shoot clusters that is used to create a `ServiceAccount` for granting access to that shoot cluster. It defaults to `accessrequests`.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adaptes the env var that holds the provider name to the one that is set by the openMCP Operator.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The env var that can be used to set the provider identity is now named `OPENMCP_PROVIDER_NAME` (previously `PROVIDER_NAME`).
```
