### PR TITLE
enable shoot-oidc-extension for all created shoots

### DIFF
--- a/internal/controllers/cluster/shoot_test.go
+++ b/internal/controllers/cluster/shoot_test.go
@@ -160,6 +160,9 @@ var _ = Describe("Shoot Logic", func() {
 			Expect(shoot.Spec.CloudProfile).To(Equal(pc.Spec.ShootTemplate.Spec.CloudProfile))
 			Expect(shoot.Spec.Region).To(Equal(pc.Spec.ShootTemplate.Spec.Region))
 			Expect(shoot.Spec.Maintenance).To(Equal(pc.Spec.ShootTemplate.Spec.Maintenance))
+			Expect(shoot.Spec.Extensions).To(ContainElements(MatchFields(IgnoreExtras, Fields{
+				"Type": Equal(cluster.GardenerOIDCExtensionType),
+			})))
 		})
 
 		It("should not update fields in an invalid way", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
We need an OIDC authentication solution to replace the old APIServer controller from the v1 architecture with the Gardener ClusterProvider. Until we have our own one, let's enable the Gardener one.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The Gardener OIDC Extension is now enabled for all created shoots.
```
