### PR TITLE
chore: renovates runs 'task generate' after upgrade

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,17 @@
       ]
     }
   ],
+  "allowedCommands": [
+    "task generate"
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "task generate"
+    ],
+    "fileFilters": [
+      "/hack/external-apis/apis.yaml/"
+    ]
+  },
   "customManagers": [
     {
       "description": "Match for gardener in hack/external-apis/apis.yaml",


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
NONE
```
