### PR TITLE
chore: update to openmcp-operator 0.14.0

### DIFF
--- a/cmd/cluster-provider-gardener/app/app.go
+++ b/cmd/cluster-provider-gardener/app/app.go
@@ -34,9 +34,8 @@ func NewClusterProviderGardenerCommand() *cobra.Command {
 }
 
 type RawSharedOptions struct {
-	Environment  string `json:"environment"`
-	ProviderName string `json:"provider-name"`
-	DryRun       bool   `json:"dry-run"`
+	Environment string `json:"environment"`
+	DryRun      bool   `json:"dry-run"`
 }
 
 type SharedOptions struct {
@@ -44,8 +43,7 @@ type SharedOptions struct {
 	PlatformCluster *clusters.Cluster
 
 	// fields filled in Complete()
-	Log          logging.Logger
-	ProviderName string
+	Log logging.Logger
 }
 
 func (o *SharedOptions) AddPersistentFlags(cmd *cobra.Command) {
@@ -56,7 +54,6 @@ func (o *SharedOptions) AddPersistentFlags(cmd *cobra.Command) {
 	// environment
 	cmd.PersistentFlags().StringVar(&o.Environment, "environment", "", "Environment name. Required. This is used to distinguish between different environments that are watching the same Onboarding cluster. Must be globally unique.")
 	// provider name
-	cmd.PersistentFlags().StringVar(&o.ProviderName, "provider-name", "", "Name of the provider resource.")
 	cmd.PersistentFlags().BoolVar(&o.DryRun, "dry-run", false, "If set, the command aborts after evaluation of the given flags.")
 }
 
@@ -72,7 +69,6 @@ func (o *SharedOptions) PrintRaw(cmd *cobra.Command) {
 func (o *SharedOptions) PrintCompleted(cmd *cobra.Command) {
 	raw := map[string]any{
 		"platformCluster": o.PlatformCluster.APIServerEndpoint(),
-		"providerName":    o.ProviderName,
 	}
 	data, err := yaml.Marshal(raw)
 	if err != nil {
@@ -87,7 +83,6 @@ func (o *SharedOptions) Complete() error {
 		return fmt.Errorf("environment must not be empty")
 	}
 	shared.SetEnvironment(o.Environment)
-	shared.SetProviderName(o.ProviderName)
 
 	// build logger
 	log, err := logging.GetLogger()

--- a/cmd/cluster-provider-gardener/app/init.go
+++ b/cmd/cluster-provider-gardener/app/init.go
@@ -83,7 +83,6 @@ func (o *InitOptions) Run(ctx context.Context) error {
 
 	log := o.Log.WithName("main")
 	log.Info("Environment", "value", o.Environment)
-	log.Info("ProviderName", "value", o.ProviderName)
 
 	// apply CRDs
 	crdManager := crdutil.NewCRDManager(openmcpconst.ClusterLabel, crds.CRDs)

--- a/cmd/cluster-provider-gardener/app/run.go
+++ b/cmd/cluster-provider-gardener/app/run.go
@@ -253,7 +253,6 @@ func (o *RunOptions) Run(ctx context.Context) error {
 
 	setupLog = o.Log.WithName("setup")
 	setupLog.Info("Environment", "value", o.Environment)
-	setupLog.Info("ProviderName", "value", o.ProviderName)
 
 	webhookServer := webhook.NewServer(webhook.Options{
 		TLSOpts: o.WebhookTLSOpts,

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,11 @@ require (
 	github.com/onsi/ginkgo/v2 v2.25.2
 	github.com/onsi/gomega v1.38.2
 	github.com/openmcp-project/cluster-provider-gardener/api v0.5.0
-	github.com/openmcp-project/openmcp-operator/api v0.12.0
+	github.com/openmcp-project/openmcp-operator/api v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.34.0
 	k8s.io/client-go v0.34.0
-	sigs.k8s.io/controller-runtime v0.22.0
+	sigs.k8s.io/controller-runtime v0.22.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/openmcp-project/controller-utils v0.19.0 h1:D4Ht3LI/Ue5yk2wdAnJEpChUV
 github.com/openmcp-project/controller-utils v0.19.0/go.mod h1:zxcbcmedLdlQ//X/nwdPvq/nM3ikyR13DbOivou2I4Y=
 github.com/openmcp-project/controller-utils/api v0.19.0 h1:2wOiLtHLVYeCSDxWJrCqCiFAxircAQ2EONIwq3QuZSI=
 github.com/openmcp-project/controller-utils/api v0.19.0/go.mod h1:qsvVfsL3xeeJ9keiKVMa50VOWmr+uR0VVejmQ7FCH18=
-github.com/openmcp-project/openmcp-operator/api v0.12.0 h1:g3Q0VFNsggDmMD4r+RmtiNwGohzu2JfEqp4RtlT5b1A=
-github.com/openmcp-project/openmcp-operator/api v0.12.0/go.mod h1:malWxgwCmDPeNklWe23rw9f9cvmq6LdIxlKmvqcYMqw=
+github.com/openmcp-project/openmcp-operator/api v0.14.0 h1:/Ogg13b/IBBmAVQEuFnOKvHuVV3o2DlrQpSQhXca0+g=
+github.com/openmcp-project/openmcp-operator/api v0.14.0/go.mod h1:mgckJa59TpgTjta8+BWHwbOxlY1zVasqQTDFQLCs6M8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -259,8 +259,8 @@ k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d h1:wAhiDyZ4Tdtt7e46e9M5ZSAJ/MnPG
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/controller-runtime v0.22.0 h1:mTOfibb8Hxwpx3xEkR56i7xSjB+nH4hZG37SrlCY5e0=
-sigs.k8s.io/controller-runtime v0.22.0/go.mod h1:FwiwRjkRPbiN+zp2QRp7wlTCzbUXxZ/D4OzuQUDwBHY=
+sigs.k8s.io/controller-runtime v0.22.1 h1:Ah1T7I+0A7ize291nJZdS1CabF/lB4E++WizgV24Eqg=
+sigs.k8s.io/controller-runtime v0.22.1/go.mod h1:FwiwRjkRPbiN+zp2QRp7wlTCzbUXxZ/D4OzuQUDwBHY=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates to latest version of openmcp-operator 0.14.0

**Which issue(s) this PR fixes**:
Problem with using it in conjunction with the latest openmcp-operator version

**Special notes for your reviewer**:
Needs oidc-config fixes. Problems in internal/controllers/accessrequest/access.go:522

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Now compatible with openmcp-operator v0.14.0
```
