### PR TITLE
feat: enable shoot name override via label

### DIFF
--- a/api/core/v1alpha1/constants.go
+++ b/api/core/v1alpha1/constants.go
@@ -10,6 +10,9 @@ const (
 	// AccessRequestFinalizer is the finalizer that is used by the AccessRequest controller on AccessRequest resources.
 	AccessRequestFinalizer = GroupName + "/accessrequest"
 
+	// ShootNameLabel is the label on Cluster resources that allows to overwrite the shoot name, which is otherwise generated based on the Cluster name and namespace.
+	ShootNameLabel = GroupName + "/shoot-name"
+
 	// ClusterConfigHashAnnotation is the name of the annotation that is used to store a hash over the names of the referenced ClusterConfig resources.
 	// This is used to detect changes in the ClusterConfig references.
 	ClusterConfigHashAnnotation = GroupName + "/clusterconfigs"

--- a/docs/config/setup.md
+++ b/docs/config/setup.md
@@ -4,7 +4,4 @@
 
 There are a few environment variables that are evaluated on startup and can be used to control the behavior of the ClusterProvider:
 
-- `OPENMCP_PROVIDER_NAME` can be overwritten to specify the provider name. It defaults to `gardener` if not set.
-  - Must be a k8s name compatible string.
-  - The provider name is used as an identifier to avoid conflicts between multiple Gardener ClusterProviders working on the same k8s cluster. Its value doesn't really matter, as long as only one instance of the ClusterProvider is working on the cluster. If multiple instances are working on the same cluster, they must all have unique provider names to avoid conflicts on reconciled resources.
 - `ACCESS_REQUEST_SERVICE_ACCOUNT_NAMESPACE` specifies the namespace on shoot clusters that is used to create a `ServiceAccount` for granting access to that shoot cluster. It defaults to `accessrequests`.

--- a/docs/resources/clusterconfig.md
+++ b/docs/resources/clusterconfig.md
@@ -100,6 +100,12 @@ Removing extensions or merging their configuration is currently not possible thi
 
 For similar reasons as for `spec.extensions`, it is possible to inject named resource references into a shoot's `spec.resources` field via the cluster config's `spec.resources`. Existing resource references with the same name will be overwritten, otherwise the respective reference will be added to the shoot manifest.
 
+## Overwriting Shoot Names
+
+Note that the name of the generated `Shoot` can also be overwritten by setting the `gardener.clusters.openmcp.cloud/shoot-name` label on a `Cluster` resource. The label has no effect if the shoot for the Cluster has already been created and specifying a shoot name for which the shoot already exists, but belongs to a different Cluster, will result in an error.
+
+This method will not result in orphaned shoots if something goes wrong and is therefore recommended over manipulating the shoot name via the `ClusterConfig` resource.
+
 ## ⚠️ Warning
 
 Note that any of the shoot's fields (except for its `status`) can be modified using the `ClusterConfig` resource. This should be done very carefully, since there is a lot of potential for creating invalid changes to the shoot manifest.

--- a/internal/controllers/cluster/testdata/test-05/platform/cluster-basic-name.yaml
+++ b/internal/controllers/cluster/testdata/test-05/platform/cluster-basic-name.yaml
@@ -1,0 +1,15 @@
+apiVersion: clusters.openmcp.cloud/v1alpha1
+kind: Cluster
+metadata:
+  name: basic-with-name
+  namespace: clusters
+  labels:
+    gardener.clusters.openmcp.cloud/shoot-name: custom-shoot-name
+spec:
+  profile: test.gardener.gcp
+  purposes:
+  - test
+  tenancy: Exclusive
+status:
+  observedGeneration: 1
+  phase: Ready

--- a/internal/controllers/shared/config.go
+++ b/internal/controllers/shared/config.go
@@ -434,5 +434,8 @@ func ShootK8sName(clusterName, clusterNamespace string) string {
 	return fmt.Sprintf("s-%s", ctrlutils.NameHashSHAKE128Base32(clusterNamespace, clusterName))
 }
 func ShootK8sNameFromCluster(c *clustersv1alpha1.Cluster) string {
+	if name, ok := c.Labels[providerv1alpha1.ShootNameLabel]; ok && name != "" {
+		return name
+	}
 	return ShootK8sName(c.Name, c.Namespace)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable shoot name overwrite via label on Cluster resource.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to overwrite the name of the `Shoot` resource by specifying the `gardener.clusters.openmcp.cloud/shoot-name` label on the `Cluster` resource. The label has no effect on Clusters with already existing shoots.
```
