### PR TITLE
rename AccessRequest secret

### DIFF
--- a/internal/controllers/accessrequest/controller.go
+++ b/internal/controllers/accessrequest/controller.go
@@ -392,7 +392,8 @@ func (r *AccessRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func defaultSecretName(ar *clustersv1alpha1.AccessRequest) string {
-	return ar.Name
+	suffix := ".kubeconfig"
+	return ctrlutils.ShortenToXCharactersUnsafe(ar.Name, ctrlutils.K8sMaxNameLength-len(suffix)) + suffix
 }
 
 type shootAccessGetter func() (*shootAccess, errutils.ReasonableError)


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the name of the secret created by the AccessRequest. It was just the AccessRequest's name before, which is fine when coming from the AccessRequest and looking for the secret, but confusing when just listing secrets.

This change renames the secret to `<access-request-name>.kubeconfig` (similar to how the ClusterProvider `kind` does it). If that exceeds the character limit, parts of the AccessRequest's name will be cut off and replaced by a hash while the `.kubeconfig` suffix will be preserved.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
This change will 'leak' secrets with the old name from existing AccessRequests, as long as the AccessRequest exists. Since the old secret has an owner reference, it will be removed when the AccessRequest is deleted.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The secrets created for `AccessRequest` resources are now named `<access-request-name>.kubeconfig`. Before, they were just named like the owning `AccessRequest` itself. Existing secrets with the old name will continue to exist until the `AccessRequest` is removed, but they will not be updated anymore.
```
