### PR TITLE
feat: wait with cluster deletion until foreign finalizers are removed

### DIFF
--- a/api/core/v1alpha1/constants.go
+++ b/api/core/v1alpha1/constants.go
@@ -43,6 +43,7 @@ const (
 
 	ClusterConditionShootManagement       = "ShootManagement"
 	ClusterConditionClusterConfigurations = "ClusterConfigurations"
+	ClusterConditionForeignFinalizers     = "ForeignFinalizers"
 
 	ProviderConfigConditionCloudProfile             = "CloudProfile"
 	ProviderConfigConditionClusterProfileManagement = "ClusterProfileManagement"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the ClusterProvider wait with the shoot deletion until all 'foreign' finalizers have been removed from the `Cluster`.

**Which issue(s) this PR fixes**:
Part of https://github.com/openmcp-project/backlog/issues/313.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The ClusterProvider Gardener will not trigger the shoot deletion anymore if the `Cluster` contains other finalizers than its own one. This allows other controllers with finalizers on the `Cluster` - likely because they deployed something on the cluster - to cleanup first before the cluster is deleted, thereby potentially preventing leaked/orphaned resources.
```
