### PR TITLE
feat: enable omitting provider name prefix in rbac

### DIFF
--- a/internal/controllers/accessrequest/access.go
+++ b/internal/controllers/accessrequest/access.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -576,7 +577,11 @@ func (r *AccessRequestReconciler) ensureOIDCAccess(ctx context.Context, ar *clus
 		for i, roleBinding := range ar.Spec.OIDC.RoleBindings {
 			// append username prefix and groups prefix to subjects
 			subjects := collections.ProjectSliceToSlice(roleBinding.Subjects, func(sub rbacv1.Subject) rbacv1.Subject {
-				sub.Name = oidcConfig.UsernameGroupsPrefix() + sub.Name
+				if suffix, ok := strings.CutPrefix(sub.Name, "::"); ok {
+					sub.Name = suffix
+				} else {
+					sub.Name = oidcConfig.UsernameGroupsPrefix() + sub.Name
+				}
 				return sub
 			})
 			// ensure (Cluster)RoleBindings

--- a/internal/controllers/accessrequest/controller_test.go
+++ b/internal/controllers/accessrequest/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -474,10 +475,12 @@ var _ = Describe("AccessRequest Controller", func() {
 					Namespace: subject.Namespace,
 				}
 				switch expected.Kind {
-				case rbacv1.GroupKind:
-					expected.Name = ar.Spec.OIDC.UsernameGroupsPrefix() + subject.Name
-				case rbacv1.UserKind:
-					expected.Name = ar.Spec.OIDC.UsernameGroupsPrefix() + subject.Name
+				case rbacv1.GroupKind, rbacv1.UserKind:
+					if suffix, ok := strings.CutPrefix(subject.Name, "::"); ok {
+						expected.Name = suffix
+					} else {
+						expected.Name = ar.Spec.OIDC.UsernameGroupsPrefix() + subject.Name
+					}
 				default:
 					expected.Name = subject.Name
 				}
@@ -503,10 +506,12 @@ var _ = Describe("AccessRequest Controller", func() {
 					Namespace: subject.Namespace,
 				}
 				switch expected.Kind {
-				case rbacv1.GroupKind:
-					expected.Name = ar.Spec.OIDC.UsernameGroupsPrefix() + subject.Name
-				case rbacv1.UserKind:
-					expected.Name = ar.Spec.OIDC.UsernameGroupsPrefix() + subject.Name
+				case rbacv1.GroupKind, rbacv1.UserKind:
+					if suffix, ok := strings.CutPrefix(subject.Name, "::"); ok {
+						expected.Name = suffix
+					} else {
+						expected.Name = ar.Spec.OIDC.UsernameGroupsPrefix() + subject.Name
+					}
 				default:
 					expected.Name = subject.Name
 				}

--- a/internal/controllers/cluster/testdata/test-05/platform/accessrequest-oidc.yaml
+++ b/internal/controllers/cluster/testdata/test-05/platform/accessrequest-oidc.yaml
@@ -22,6 +22,8 @@ spec:
         name: foo
       - kind: Group
         name: bar
+      - kind: Group
+        name: "::asdf" # no prefix should be appended
       roleRefs:
       - kind: ClusterRole
         name: foo


### PR DESCRIPTION
**What this PR does / why we need it**:
Binding to a pre-defined Group such as `system:authenticated` is currently not possible with AccessReqests, because the subject's name is always prefixed with the provider name. This PR adds a possibility to configure that the provider name prefix should be omitted.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
For subjects with kind `Group` or `User` in an `AccessRequest`'s `spec. oidc.roleBindings[*].subjects` entry, it is now possible to prefix the `name` with `::`. This will cause the ClusterProvider to just remove this prefix instead of applying the oidc provider name when creating (Cluster)RoleBindings out of this configuration. By using this method, it is now possible to bind to k8s-predefined Groups such as `system:authenticated` by specifying `::system:authenticated` as subject name, for example.
```
