### PR TITLE
Fix Cluster controller notification bug.

### DIFF
--- a/internal/controllers/config/controller.go
+++ b/internal/controllers/config/controller.go
@@ -81,7 +81,7 @@ func (r *GardenerProviderConfigReconciler) Reconcile(ctx context.Context, req re
 			r.SetProfileForProviderConfiguration(req.Name, profile)
 
 			// notify clusters about new/updated profile
-			if oldProfile == nil || isProfileUpdated(oldProfile, profile) {
+			if oldProfile == nil || IsProfileUpdated(oldProfile, profile) {
 				// this is required because clusters with unknown profiles are ignored by the controller
 				// so they would only be reconciled if somehow triggered by a modification from the outside
 				// additionally, when a profile is updated (e.g., ShootTemplate changes), clusters need to be notified
@@ -335,7 +335,7 @@ func (r *GardenerProviderConfigReconciler) notifyClustersAboutProfileUpdate(ctx 
 	return nil
 }
 
-func isProfileUpdated(oldProfile, newProfile *shared.Profile) bool {
+func IsProfileUpdated(oldProfile, newProfile *shared.Profile) bool {
 	if oldProfile == nil || newProfile == nil {
 		return oldProfile != newProfile
 	}

--- a/internal/controllers/config/controller_test.go
+++ b/internal/controllers/config/controller_test.go
@@ -289,3 +289,44 @@ var _ = Describe("ProviderConfig Controller", func() {
 	})
 
 })
+
+var _ = Describe("isProfileUpdated", func() {
+	It("should return false when ProviderConfig.Spec is identical", func() {
+		spec := providerv1alpha1.ProviderConfigSpec{
+			ProviderRef:  commonapi.LocalObjectReference{Name: "gardener"},
+			LandscapeRef: commonapi.LocalObjectReference{Name: "landscape-1"},
+			Project:      "my-project",
+		}
+		oldProfile := &shared.Profile{
+			ProviderConfig: &providerv1alpha1.ProviderConfig{
+				Spec: spec,
+			},
+		}
+		newProfile := &shared.Profile{
+			ProviderConfig: &providerv1alpha1.ProviderConfig{
+				Spec: spec,
+			},
+		}
+		result := config.IsProfileUpdated(oldProfile, newProfile)
+		Expect(result).To(BeFalse())
+	})
+
+	It("should return true when ProviderConfig.Spec differs", func() {
+		oldProfile := &shared.Profile{
+			ProviderConfig: &providerv1alpha1.ProviderConfig{
+				Spec: providerv1alpha1.ProviderConfigSpec{
+					Project: "project-1",
+				},
+			},
+		}
+		newProfile := &shared.Profile{
+			ProviderConfig: &providerv1alpha1.ProviderConfig{
+				Spec: providerv1alpha1.ProviderConfigSpec{
+					Project: "project-2",
+				},
+			},
+		}
+		result := config.IsProfileUpdated(oldProfile, newProfile)
+		Expect(result).To(BeTrue())
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a notification bug in the Cluster Controller where updates to a cluster's ProviderConfig could change cluster-related metadata without triggering the controller's notification path when the controller did not perform a full reconcile. The root cause was an overly strict condition that skipped emitting notifications for ProviderConfig-only updates. This PR fixes that condition so ProviderConfig updates that should notify subscribers do so reliably. Unit and small integration tests were added to cover the previously-missed case.

**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/backlog/issues/327

**Special notes for your reviewer**:
- The change is limited to the controller notification/send path (no API or database schema changes).
- No breaking changes; safe to backport to recent maintenance releases if desired.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix a bug where the Cluster Controller was not notified if the ProviderConfig was updated and didn't reconcile the cluster.
```