### PR TITLE
chore: align renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,17 @@
   },
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "description": "Ignore version update for our own API",
+      "matchManagers": [
+        "gomod"
+      ],
+      "enabled": false,
+      "matchPackageNames": [
+        "github.com/openmcp-project/cluster-provider-gardener/api"
+      ]
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,53 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "git-submodules": {
-    "enabled": true
-  },
-  "minimumReleaseAge": "0 days",
-  "gitIgnoredAuthors": [
-    "github-actions[bot]@users.noreply.github.com"
-  ],
   "extends": [
     "config:recommended",
     "config:best-practices",
     "security:openssf-scorecard",
     "helpers:pinGitHubActionDigests",
-    ":rebaseStalePrs"
+    ":rebaseStalePrs",
+    ":enableVulnerabilityAlerts"
   ],
+  "git-submodules": {
+    "enabled": true
+  },
   "postUpdateOptions": [
     "gomodTidy"
-  ],
-  "packageRules": [
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "go"
-      ],
-      "matchDepTypes": [
-        "golang"
-      ],
-      "rangeStrategy": "bump"
-    },
-    {
-      "matchPackageNames": [
-        "github.com/openmcp-project/*"
-      ],
-      "description": "Update all components from openmcp-project immediately",
-      "rebaseWhen": "auto",
-      "minimumReleaseAge": "0 days",
-      "enabled": true
-    },
-    {
-      "description": "Ignore version update for our own API",
-      "matchManagers": [
-        "gomod"
-      ],
-      "enabled": false,
-      "matchPackageNames": [
-        "github.com/openmcp-project/cluster-provider-gardener/api"
-      ]
-    }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the renovate config according to [service-provider-template](https://github.com/openmcp-project/service-provider-template/blob/main/renovate.json).

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Update renovate config according to service-provider-template
```
