### PR TITLE
fix: don't error if OpenIDConnect resource kind is not known

### DIFF
--- a/internal/controllers/accessrequest/access.go
+++ b/internal/controllers/accessrequest/access.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -309,6 +310,10 @@ func (r *AccessRequestReconciler) cleanupOpenIDConnectResources(ctx context.Cont
 	errs := errutils.NewReasonableErrorList()
 	oidcs := &oidcv1alpha1.OpenIDConnectList{}
 	if err := sac.Client.List(ctx, oidcs, selector); err != nil {
+		if meta.IsNoMatchError(err) {
+			log.Info("Skipping cleanup of OpenIDConnect resources, because kind is not known (Gardener OIDC extension disabled?)", "error", err.Error())
+			return errs.Aggregate()
+		}
 		errs.Append(errutils.WithReason(fmt.Errorf("error listing OpenIDConnect resources: %w", err), cconst.ReasonShootClusterInteractionProblem))
 		return errs.Aggregate()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
#188 allowed to disable the default OIDC extension. However, this would still cause an error, as the AccessRequest controller checks for leftover `OpenIDConnect` resources, which fails due to the kind not being registered if the OIDC extension is disabled. This PR changes the error in this scenario to a log message without an error.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The AccessRequest controller does not throw an error anymore if the `OpenIDConnect` api kind is unknown. This could happen as a result of disabling the default OIDC extension.
```
