### PR TITLE
fix: re-add renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
     ":rebaseStalePrs",
     ":enableVulnerabilityAlerts"
   ],
+  "gitIgnoredAuthors": [
+    "github-actions[bot]@users.noreply.github.com"
+  ],
   "git-submodules": {
     "enabled": true
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-adds some configuration which was wrongfully removed with #211 

**Which issue(s) this PR fixes**:
Fixes the renovate generate github action.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
