### PR TITLE
feat: ensure namespace exists before reconciling role and role binding

### DIFF
--- a/internal/controllers/accessrequest/access.go
+++ b/internal/controllers/accessrequest/access.go
@@ -387,6 +387,14 @@ func (r *AccessRequestReconciler) renewToken(ctx context.Context, ar *clustersv1
 			roleName = fmt.Sprintf("openmcp:permission:%s:%d", ctrlutils.NameHashSHAKE128Base32(shared.Environment(), shared.ProviderName(), ar.Namespace, ar.Name), i)
 		}
 		if permission.Namespace != "" {
+			// ensure namespace for role + binding if not disabled
+			if !permission.DisableAutomaticNamespaceCreation {
+				log.Debug("Ensuring Namespace for Role and RoleBinding", "roleName", roleName, "namespace", permission.Namespace)
+				if _, err := clusteraccess.EnsureNamespace(ctx, sac.Client, permission.Namespace); err != nil {
+					errs.Append(errutils.WithReason(fmt.Errorf("error ensuring namespace '%s' for role '%s' in shoot '%s': %w", permission.Namespace, roleName, sac.Shoot.Name, err), cconst.ReasonShootClusterInteractionProblem))
+					continue
+				}
+			}
 			// ensure role + binding
 			log.Debug("Ensuring Role and RoleBinding", "roleName", roleName, "namespace", permission.Namespace)
 			rb, r, err := clusteraccess.EnsureRoleAndBinding(ctx, sac.Client, roleName, permission.Namespace, subjects, permission.Rules, expectedLabels...)
@@ -560,6 +568,14 @@ func (r *AccessRequestReconciler) ensureOIDCAccess(ctx context.Context, ar *clus
 				roleName = fmt.Sprintf("openmcp:%s:%d", ctrlutils.NameHashSHAKE128Base32(shared.Environment(), shared.ProviderName(), ar.Namespace, ar.Name), i)
 			}
 			if roleDef.Namespace != "" {
+				// ensure namespace for role + rolebinding if not disabled
+				if !roleDef.DisableAutomaticNamespaceCreation {
+					log.Debug("Ensuring Namespace for Role and RoleBinding", "roleName", roleName, "namespace", roleDef.Namespace)
+					if _, err := clusteraccess.EnsureNamespace(ctx, sac.Client, roleDef.Namespace); err != nil {
+						errs.Append(errutils.WithReason(fmt.Errorf("error ensuring namespace '%s' for role '%s' in shoot '%s': %w", roleDef.Namespace, roleName, sac.Shoot.Name, err), cconst.ReasonShootClusterInteractionProblem))
+						continue
+					}
+				}
 				log.Debug("Ensuring Role", "roleName", roleName, "namespace", roleDef.Namespace)
 				r, err := clusteraccess.EnsureRole(ctx, sac.Client, roleName, roleDef.Namespace, roleDef.Rules, expectedLabels...)
 				if err != nil {

--- a/internal/controllers/accessrequest/controller_test.go
+++ b/internal/controllers/accessrequest/controller_test.go
@@ -267,8 +267,16 @@ var _ = Describe("AccessRequest Controller", func() {
 
 			// --------------------------------------------------------------------------------
 
-			// role + binding from permissions field
+			// namespace, role + binding from permissions field
 			{
+				createdNS := &corev1.Namespace{}
+				createdNS.SetName(ar.Spec.Token.Permissions[1].Namespace)
+				Expect(env.Client(shootCluster).Get(env.Ctx, client.ObjectKeyFromObject(createdNS), createdNS)).To(Succeed())
+
+				notCreatedNS := &corev1.Namespace{}
+				notCreatedNS.SetName(ar.Spec.Token.Permissions[2].Namespace)
+				Expect(env.Client(shootCluster).Get(env.Ctx, client.ObjectKeyFromObject(notCreatedNS), notCreatedNS)).ToNot(Succeed())
+
 				rl := &rbacv1.RoleList{}
 				Expect(env.Client(shootCluster).List(env.Ctx, rl, labelSelector, client.InNamespace(ar.Spec.Token.Permissions[1].Namespace))).To(Succeed())
 				Expect(rl.Items).To(HaveLen(1))
@@ -567,7 +575,15 @@ var _ = Describe("AccessRequest Controller", func() {
 				Expect(crb.Subjects).To(ContainElement(expected))
 			}
 
-			// role + binding
+			// namespace, role + binding
+			createdNS := &corev1.Namespace{}
+			createdNS.SetName(ar.Spec.OIDC.Roles[1].Namespace)
+			Expect(env.Client(shootCluster).Get(env.Ctx, client.ObjectKeyFromObject(createdNS), createdNS)).To(Succeed())
+
+			notCreatedNS := &corev1.Namespace{}
+			notCreatedNS.SetName(ar.Spec.OIDC.Roles[2].Namespace)
+			Expect(env.Client(shootCluster).Get(env.Ctx, client.ObjectKeyFromObject(notCreatedNS), notCreatedNS)).ToNot(Succeed())
+
 			rl := &rbacv1.RoleList{}
 			Expect(env.Client(shootCluster).List(env.Ctx, rl, labelSelector, client.InNamespace(ar.Spec.OIDC.Roles[1].Namespace))).To(Succeed())
 			Expect(rl.Items).To(HaveLen(1))

--- a/internal/controllers/cluster/testdata/test-05/platform/accessrequest-oidc.yaml
+++ b/internal/controllers/cluster/testdata/test-05/platform/accessrequest-oidc.yaml
@@ -51,5 +51,15 @@ spec:
         - "*"
         verbs:
         - "*"
+    - name: qux
+      namespace: baz
+      rules:
+        - apiGroups:
+          - "*"
+          resources:
+          - "*"
+          verbs:
+          - "*"
+      disableAutomaticNamespaceCreation: true
 status:
   phase: Pending

--- a/internal/controllers/cluster/testdata/test-05/platform/accessrequest.yaml
+++ b/internal/controllers/cluster/testdata/test-05/platform/accessrequest.yaml
@@ -29,6 +29,16 @@ spec:
         - "*"
         verbs:
         - "*"
+    - name: qux
+      namespace: baz
+      rules:
+        - apiGroups:
+          - "*"
+          resources:
+          - "*"
+          verbs:
+          - "*"
+      disableAutomaticNamespaceCreation: true
     roleRefs:
     - kind: Role
       name: secret-viewer


### PR DESCRIPTION
On-behalf-of: @SAP nico.andres@sap.com

**What this PR does / why we need it**:
Make sure that namespace already exists or is created when reconciling an access request which contains namespaced permissions.
**Which issue(s) this PR fixes**:
Related to https://github.com/openmcp-project/openmcp-operator/issues/282

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Ensure namespace exists before reconciling namespaced role and role binding
```
