### PR TITLE
fix: providerconfig CRD

### DIFF
--- a/api/crds/manifests/gardener.clusters.openmcp.cloud_providerconfigs.yaml
+++ b/api/crds/manifests/gardener.clusters.openmcp.cloud_providerconfigs.yaml
@@ -116,6 +116,23 @@ spec:
                 properties:
                   metadata:
                     description: Standard object metadata.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
                     type: object
                   spec:
                     description: Specification of the desired behavior of the Shoot.


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the build repo to a version which contains https://github.com/openmcp-project/build/pull/157, which fixes the missing metadata schema in the `ProviderConfig` CRD.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The CRD of the `ProviderConfig` resource now contains the schema for the `spec.shootTemplate.metadata` field, which was previously missing. This fixes the issue that labels and annotations set in the config's shoot template were not propagated to the generated `Shoot` resources (unless the CRD was patched manually afterwards).
```
