### PR TITLE
chore(deps): renovate org-preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,22 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>openmcp-project/.github:renovate-config",
+    ":enableVulnerabilityAlerts"
+  ],
   "git-submodules": {
     "enabled": true
   },
   "minimumReleaseAge": "0 days",
-  "extends": [
-    "config:recommended",
-    "config:best-practices",
-    "security:openssf-scorecard",
-    "helpers:pinGitHubActionDigests",
-    ":rebaseStalePrs",
-    ":enableVulnerabilityAlerts"
-  ],
   "gitIgnoredAuthors": [
     "github-actions[bot]@users.noreply.github.com"
-  ],
-  "postUpdateOptions": [
-    "gomodTidy"
   ],
   "packageRules": [
     {
@@ -28,14 +21,6 @@
       "matchPackageNames": [
         "github.com/openmcp-project/cluster-provider-gardener/api"
       ]
-    },
-    {
-      "description": "Group openmcp-project/build submodule and workflow updates",
-      "matchDepNames": [
-        "hack/common",
-        "openmcp-project/build"
-      ],
-      "groupName": "openmcp-project/build"
     },
     {
       "description": "Update and automerge all components from openmcp-project immediately in one singe PR",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,44 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>openmcp-project/.github:renovate-config",
-    ":enableVulnerabilityAlerts"
-  ],
-  "git-submodules": {
-    "enabled": true
-  },
-  "minimumReleaseAge": "0 days",
-  "gitIgnoredAuthors": [
-    "github-actions[bot]@users.noreply.github.com"
-  ],
-  "packageRules": [
-    {
-      "description": "Ignore version update for our own API",
-      "matchManagers": [
-        "gomod"
-      ],
-      "enabled": false,
-      "matchPackageNames": [
-        "github.com/openmcp-project/cluster-provider-gardener/api"
-      ]
-    },
-    {
-      "description": "Update and automerge all components from openmcp-project immediately in one singe PR",
-      "matchManagers": [
-        "gomod"
-      ],
-      "groupName": "openmcp-project Go dependencies",
-      "groupSlug": "openmcp-go-deps",
-      "automerge": true,
-      "automergeType": "pr",
-      "prPriority": 10,
-      "semanticCommitType": "chore",
-      "rebaseWhen": "auto",
-      "minimumReleaseAge": "0 days",
-      "enabled": true,
-      "matchPackageNames": [
-        "/^github.com/openmcp-project//"
-      ]
-    }
+    "github>openmcp-project/.github:renovate-config"
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves `renovate.json` to `.github/renovate.json` and references the new org-level preset
- `extends`: recommended + best-practices + openssf-scorecard + pinGitHubActionDigests + rebaseStalePrs
- `postUpdateOptions`: gomodTidy
- golang `rangeStrategy: bump` rule
- `openmcp-project/build` group rule
- `openmcp-project` Go dependencies grouped into one PR

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other dependency

```